### PR TITLE
chore: Make test runs short and tolerable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 .idea/
+.env.local

--- a/src/benchie/benchmark.ts
+++ b/src/benchie/benchmark.ts
@@ -68,7 +68,9 @@ export class Scenario implements IScenario {
 
   constructor(params: IScenarioParams) {
     this.beforeAll = params.beforeAll;
+    this.afterAll = params.afterAll;
     this.beforeEach = params.beforeEach;
+    this.afterEach = params.afterEach;
     this.method = params.method;
     this.body = params.body;
     this.title = params.title;
@@ -103,7 +105,9 @@ export class ScenarioBuilder implements IScenarioBuilder {
       method: method,
       title: this.params.title,
       beforeEach: this.params.beforeEach,
+      afterEach: this.params.afterEach,
       beforeAll: this.params.beforeAll,
+      afterAll: this.params.afterAll,
     });
   }
 

--- a/src/benchie/benchmark.ts
+++ b/src/benchie/benchmark.ts
@@ -12,6 +12,8 @@ export interface IMethodBuilder {
 export interface IScenarioBuilder extends IMethodBuilder {
   beforeEach(task: Task): void;
   beforeAll(task: Task): void;
+  afterAll(task: Task): void;
+  afterEach(task: Task): void;
 }
 
 export interface IMethod {

--- a/src/benchie/bin/benchie.ts
+++ b/src/benchie/bin/benchie.ts
@@ -14,6 +14,10 @@ dotenv.config({
   path: ".env",
   override: true,
 });
+dotenv.config({
+  path: ".env.local",
+  override: true,
+});
 
 const cwd = new URL(`file://${process.cwd()}/`);
 

--- a/src/benchie/results-output.ts
+++ b/src/benchie/results-output.ts
@@ -15,9 +15,9 @@ export class ResultsOutputText {
       console.log(filename);
       for (let r of results) {
         console.log(`  ${r.title}`);
-        console.log(`    mean: ${r.stats.mean.toString(3)}`);
-        console.log(`    min: ${r.stats.min.toString(3)}`);
-        console.log(`    max: ${r.stats.max.toString(3)}`);
+        console.log(`    mean: ${r.stats.mean.toFixed(3)}`);
+        console.log(`    min: ${r.stats.min.toFixed(3)}`);
+        console.log(`    max: ${r.stats.max.toFixed(3)}`);
         // console.log(`    error: ${r.stats.error.toString(3)}`);
       }
     }

--- a/src/load-pinned-stream.bench.ts
+++ b/src/load-pinned-stream.bench.ts
@@ -12,18 +12,24 @@ scenario("Load stream that is pinned", (perform) => {
     ceramic = await createCeramic();
   });
 
+  perform.afterAll(async () => {
+    await ceramic.close();
+  });
+
   perform.beforeEach(async () => {
     const content0 = {
       foo: `hello-${Math.random()}`,
     };
-    const tile = await TileDocument.create(ceramic, content0);
+    const tile = await TileDocument.create(ceramic, content0, undefined, {
+      anchor: false,
+    });
     const content1 = { foo: `world-${Math.random()}` };
-    await tile.update(content1);
+    await tile.update(content1, undefined, { anchor: false });
     await ceramic.pin.add(tile.id);
     streamId = tile.id;
   });
 
-  perform.times(100).run(async () => {
+  perform.times(10).run(async () => {
     await TileDocument.load(ceramic, streamId);
   });
 });

--- a/src/load-pinned-stream.bench.ts
+++ b/src/load-pinned-stream.bench.ts
@@ -23,7 +23,7 @@ scenario("Load stream that is pinned", (perform) => {
     streamId = tile.id;
   });
 
-  perform.times(1).run(async () => {
+  perform.times(100).run(async () => {
     await TileDocument.load(ceramic, streamId);
   });
 });

--- a/src/load-stream-over-network.bench.ts
+++ b/src/load-stream-over-network.bench.ts
@@ -6,12 +6,17 @@ import { scenario } from "./benchie/benchmark.js";
 
 scenario("Load stream over network", (perform) => {
   let streamId: StreamID;
-  let ceramic: CeramicApi;
+  let primaryCeramic: CeramicApi;
+  let secondaryCeramic: CeramicApi;
 
   perform.beforeAll(async () => {
-    const secondaryCeramic = await createCeramic(
+    primaryCeramic = await createCeramic(process.env.CERAMIC_ENDPOINT);
+    secondaryCeramic = await createCeramic(
       process.env.SECONDARY_CERAMIC_ENDPOINT
     );
+  });
+
+  perform.beforeEach(async () => {
     const content0 = {
       foo: `hello-${Math.random()}`,
     };
@@ -23,10 +28,9 @@ scenario("Load stream over network", (perform) => {
     await tile.update(content1, null, { anchor: false, pin: true });
 
     streamId = tile.id;
-    ceramic = await createCeramic(process.env.CERAMIC_ENDPOINT);
   });
 
-  perform.times(1).run(async () => {
-    await TileDocument.load(ceramic, streamId);
+  perform.times(100).run(async () => {
+    await TileDocument.load(primaryCeramic, streamId);
   });
 });

--- a/src/load-stream-over-network.bench.ts
+++ b/src/load-stream-over-network.bench.ts
@@ -16,6 +16,11 @@ scenario("Load stream over network", (perform) => {
     );
   });
 
+  perform.afterAll(async () => {
+    await primaryCeramic.close()
+    await secondaryCeramic.close()
+  })
+
   perform.beforeEach(async () => {
     const content0 = {
       foo: `hello-${Math.random()}`,
@@ -30,7 +35,7 @@ scenario("Load stream over network", (perform) => {
     streamId = tile.id;
   });
 
-  perform.times(100).run(async () => {
+  perform.times(10).run(async () => {
     await TileDocument.load(primaryCeramic, streamId);
   });
 });

--- a/src/update-pinned-stream.bench.ts
+++ b/src/update-pinned-stream.bench.ts
@@ -11,17 +11,22 @@ scenario("Update stream that is pinned", (perform) => {
     ceramic = await createCeramic();
   });
 
+  perform.afterAll(async () => {
+    await ceramic.close();
+  });
+
   perform.beforeEach(async () => {
     const content0 = {
       foo: `hello-${Math.random()}`,
     };
     tile = await TileDocument.create(ceramic, content0, null, {
       pin: true,
+      anchor: false,
     });
   });
 
   perform.times(10).run(async () => {
     const content1 = { foo: `world-${Math.random()}` };
-    await tile.update(content1);
+    await tile.update(content1, undefined, { anchor: false });
   });
 });


### PR DESCRIPTION
- Add `afterAll` and `afterEach` hooks to types
- Parse .env.local, it is now ignored by Git
- Run scenarios 10 times
- Output metrics in decimal number, instead of base 3 before