### PR TITLE
feat: Push Docker image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -33,7 +33,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push perf image
         env:
-          IMAGE_ID_1: "ceramicnetwork/perf"
+          IMAGE_ID_1: "ceramicnetwork/benchie"
         run: |
           EXTRA_TAGS=""
           if [[ "${{ env.ENV_TAG }}" == "prod" ]]; then

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,48 @@
+name: Publish images to Docker Hub
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - ".github/**"
+  workflow_dispatch: # manually triggered
+
+jobs:
+  push_image:
+    name: Build and push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Set branch name
+        run: echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
+      - name: Set sha tag
+        run: |
+          SHA_TAG=$(git rev-parse --short=12 "${{ github.sha }}")
+          echo "SHA_TAG=$SHA_TAG" >> $GITHUB_ENV
+      - name: Set main branch tag
+        if: ${{ env.BRANCH == 'main' }}
+        run: |
+          echo "ENV_TAG=prod" >> $GITHUB_ENV
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push perf image
+        env:
+          IMAGE_ID_1: "ceramicnetwork/perf"
+        run: |
+          EXTRA_TAGS=""
+          if [[ "${{ env.ENV_TAG }}" == "prod" ]]; then
+            EXTRA_TAGS="--tag $IMAGE_ID_1:latest"
+          fi
+
+          docker buildx build . --file Dockerfile --output 'type=image,push=true' \
+            --tag $IMAGE_ID_1:${{ env.ENV_TAG }} \
+            --tag $IMAGE_ID_1:${{ env.SHA_TAG }} \
+            --tag $IMAGE_ID_1:${{ github.sha }}  \
+            --tag $IMAGE_ID_1:${{ env.BRANCH }}  \
+            $EXTRA_TAGS


### PR DESCRIPTION
In case we decide to go with vanilla docker image in Clayground, it makes sense to build a docker image and push it to the repo.